### PR TITLE
Simplify usage for Linux users.

### DIFF
--- a/lighthouse-v2-manager.py
+++ b/lighthouse-v2-manager.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import asyncio
 import sys
 import re


### PR DESCRIPTION
This allows calling the lighthouse manager like
    ./lighthouse-v2-manager.py [args]
instead of
    python3 ./lighthouse-v2-manager.py [args]