### PR TITLE
Skip devices with name of NoneType

### DIFF
--- a/lighthouse-v2-manager.py
+++ b/lighthouse-v2-manager.py
@@ -53,7 +53,7 @@ async def run(loop, lh_macs):
 		devices = await discover()
 		for d in devices:
 			deviceOk = False
-			if d.name.find("LHB-") != 0:
+			if type(d.name) != str or d.name.find("LHB-") != 0:
 				continue
 			print (">> Found potential Valve Lighthouse at '"+ d.address +"' with name '"+ d.name +"'...")
 			services = None


### PR DESCRIPTION
This fixes this error I was getting running the python script on Windows 11.  Although I am not certain it is a Windows 11 thing necessarily!  (I also had trouble at this same spot running the .exe, but the error from the .exe didn't indicate anything like this.)

```
>> This seems to be a valid V2 Base Station.

Traceback (most recent call last):
  File "C:\Program Files\LH-Manager\lighthouse-v2-manager.py", line 157, in <module>
    loop.run_until_complete(run(loop, lh_macs))
  File "C:\Users\me\AppData\Local\Programs\Python\Python311\Lib\asyncio\base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "C:\Program Files\LH-Manager\lighthouse-v2-manager.py", line 56, in run
    if d.name.find("LHB-") != 0:
       ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'find'
```