### PR TITLE
Explicitly importing library, fixes issues with windows 11 not working

### DIFF
--- a/lighthouse-v2-manager.py
+++ b/lighthouse-v2-manager.py
@@ -4,6 +4,7 @@ import asyncio
 import sys
 import re
 import os
+import bleak
 
 __PWR_SERVICE        = "00001523-1212-efde-1523-785feabcd124"
 __PWR_CHARACTERISTIC = "00001525-1212-efde-1523-785feabcd124"


### PR DESCRIPTION
import bleak, fixes win11 not working